### PR TITLE
feat!: change default target to node 14

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,7 +36,7 @@ const argv = cli({
 		},
 		target: {
 			type: [String],
-			default: [`node${process.versions.node}`],
+			default: ['node14'],
 			description: 'Environments to support. `target` in tsconfig.json is automatically added. Defaults to the current Node.js version.',
 			alias: 't',
 		},


### PR DESCRIPTION
Closes #13. It can be interpreted as a breaking change for anyone who still has Node <14 installed on their machine for pkgroll and didn't set a specific target. I don't know if you want to mark this as a major release, however.