### PR TITLE
feat: allow TypeScript 5 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"prepack": "pnpm build && clean-pkg-json"
 	},
 	"peerDependencies": {
-		"typescript": "^4.1"
+		"typescript": "^4.1 || ^5.0"
 	},
 	"peerDependenciesMeta": {
 		"typescript": {


### PR DESCRIPTION
I am adjusting the TypeScript peer dependency to allow v5 as well. Tests seem to pass even when I bump the TS version. Let me know if I should bump the dev dependencies too. I skipped that for now because rollup has a peer dependency for v4 and would need to upgrade that with a major version. 