### PR TITLE
Disable `composite` for type declarations

### DIFF
--- a/src/utils/get-rollup-configs.ts
+++ b/src/utils/get-rollup-configs.ts
@@ -49,6 +49,7 @@ const getConfig = {
 				resolveTypescriptMjsCts(),
 				dts.default({
 					respectExternal: true,
+					compilerOptions: { composite: false },
 				}) as Plugin,
 			],
 			output: [] as unknown as Output,

--- a/tests/fixture-monorepo/packages/one/src/index.ts
+++ b/tests/fixture-monorepo/packages/one/src/index.ts
@@ -1,0 +1,1 @@
+export { Name } from './name.js';

--- a/tests/fixture-monorepo/packages/one/src/name.ts
+++ b/tests/fixture-monorepo/packages/one/src/name.ts
@@ -1,0 +1,3 @@
+declare const name: unique symbol;
+
+export type Name = string & { [name]: never };

--- a/tests/fixture-monorepo/packages/one/tsconfig.json
+++ b/tests/fixture-monorepo/packages/one/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"compilerOptions": {
+		"jsx": "react",
+		"moduleResolution": "node",
+		"composite": true,
+		"outDir": "dist"
+	},
+	"include": ["src/index.ts"]
+}

--- a/tests/fixture-monorepo/packages/two/src/index.ts
+++ b/tests/fixture-monorepo/packages/two/src/index.ts
@@ -1,0 +1,5 @@
+import { Name } from '@org/one';
+
+export function sayHello(name: Name) {
+	console.log('Hello', name);
+}

--- a/tests/fixture-monorepo/packages/two/tsconfig.json
+++ b/tests/fixture-monorepo/packages/two/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"compilerOptions": {
+		"jsx": "react",
+		"moduleResolution": "node",
+		"composite": true,
+		"outDir": "dist"
+	},
+	"include": ["src/index.ts"],
+	"references": [{ "path": "../one" }]
+}

--- a/tests/fixture-monorepo/tsconfig.json
+++ b/tests/fixture-monorepo/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"moduleResolution": "node"
+	},
+	"resources": [{ "path": "./packages/one" }, { "path": "./packages/two" }]
+}


### PR DESCRIPTION
Disable `composite` for type declarations

We are using pkgroll with Typescript monorepos (managed by pnpm workspaces) and project references. The latter requires `compilerOptions.composite = true` in referenced projects for most `tsc` invocations. If you set `references` without `compilerOptions.composite = true`, `tsc` will fail, indicating that `composite` needs to be set.

When I run `pkgroll` and have `composite` set, I get TS6307 for every file included from `src/index.ts`. rollup-plugin-dts does not handle `composite` (see Swatinem/rollup-plugin-dts#127, which was closed without fix or explanation). I looked at several other related tools (rollup-plugin-typescript2, rollup-plugin-ts, others mentioned in Swatinem/rollup-plugin-dts) and could not get any of them working to build *just* the DTS files (rollup-plugin-typescript2 was the most promising, but I could not get it working in the time that I allotted for this investigation).

Going back to rollup-plugin-dts, we find the `compilerOptions` option, and I tried explicitly setting `composite: false`, which allows my type files to build again without errors.

I don't think that this is the *correct* fix; ideally, rollup-plugin-dts would be fixed to better handle composite projects *or* would override `composite` at all times. An alternative change, although much more invasive to pkgroll, would be to have pkgroll accept an *alternate* `tsconfig.json` as a parameter:

```console
$ pkgroll --tsconfig tsconfig.pkgroll.json
```

In the short term, this has eliminated the build issue that I have been seeing, and it may be sufficient to resolve this until a better fix can be determined in some way, whether by a `--tsconfig` parameter, upstream fixes, or changing to a different bundler plugin for type declaration plugins.

This issue can be seen at:

https://github.com/halostatue/pkgroll-monorepo-types-issue