### PR TITLE
feat: support custom `tsconfig.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ Pass in a Node.js target that that doesn't support it to strip the `node:` proto
 pkgroll --target=node12.19
 ```
 
+### Alternative tsconfig.json
+
+By default, _Pkgroll_ looks for `tsconfig.json` configuration file. You can alter this behavior and use your custom filename with the `--tsconfig` flag:
+
+```sh
+pkgroll --tsconfig=tsconfig.build.json
+```
+
 ### Export condition
 
 Similarly to the target, the export condition specifies which fields to read from when evaluating [export](https://nodejs.org/api/packages.html#exports) and [import](https://nodejs.org/api/packages.html#imports) maps.

--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ Pass in a Node.js target that that doesn't support it to strip the `node:` proto
 pkgroll --target=node12.19
 ```
 
-### Alternative tsconfig.json
+### Custom `tsconfig.json` path
 
-By default, _Pkgroll_ looks for `tsconfig.json` configuration file. You can alter this behavior and use your custom filename with the `--tsconfig` flag:
+By default, _Pkgroll_ looks for `tsconfig.json` configuration file in the current working directory. You can pass in a custom `tsconfig.json` path with the `--tsconfig` flag:
 
 ```sh
 pkgroll --tsconfig=tsconfig.build.json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { getAliases } from './utils/parse-package-json/get-aliases.js';
 import { normalizePath } from './utils/normalize-path.js';
 import { getSourcePath } from './utils/get-source-path.js';
 import { getRollupConfigs } from './utils/get-rollup-configs.js';
-import { parseTsconfig } from 'get-tsconfig';
+import { getTsconfig } from './utils/get-tsconfig';
 import { log } from './utils/log.js';
 import { cleanDist } from './utils/clean-dist.js';
 
@@ -46,7 +46,6 @@ const argv = cli({
 			type: String,
 			description: 'Use a given tsconfig file',
 			alias: 'c',
-			default: 'tsconfig.json',
 		},
 		watch: {
 			type: Boolean,
@@ -115,9 +114,9 @@ const cwd = process.cwd();
  */
 const sourcePath = normalizePath(argv.flags.src, true);
 const distPath = normalizePath(argv.flags.dist, true);
-const tsconfig = parseTsconfig(argv.flags.tsconfig);
 
-const tsconfigTarget = tsconfig?.compilerOptions?.target;
+const tsconfig = getTsconfig(cwd, argv.flags.tsconfig);
+const tsconfigTarget = tsconfig.config.compilerOptions?.target;
 if (tsconfigTarget) {
 	argv.flags.target.push(tsconfigTarget);
 }
@@ -160,7 +159,7 @@ if (tsconfigTarget) {
 		argv.flags,
 		getAliases(packageJson, cwd),
 		packageJson,
-		tsconfig
+		tsconfig,
 	);
 
 	if (argv.flags.cleanDist) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -115,7 +115,7 @@ const cwd = process.cwd();
 const sourcePath = normalizePath(argv.flags.src, true);
 const distPath = normalizePath(argv.flags.dist, true);
 
-const tsconfig = getTsconfig(cwd, argv.flags.tsconfig);
+const tsconfig = getTsconfig(argv.flags.tsconfig);
 const tsconfigTarget = tsconfig?.config.compilerOptions?.target;
 if (tsconfigTarget) {
 	argv.flags.target.push(tsconfigTarget);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { getAliases } from './utils/parse-package-json/get-aliases.js';
 import { normalizePath } from './utils/normalize-path.js';
 import { getSourcePath } from './utils/get-source-path.js';
 import { getRollupConfigs } from './utils/get-rollup-configs.js';
-import { tsconfig } from './utils/tsconfig.js';
+import { parseTsconfig } from 'get-tsconfig';
 import { log } from './utils/log.js';
 import { cleanDist } from './utils/clean-dist.js';
 
@@ -41,6 +41,12 @@ const argv = cli({
 			default: [`node${process.versions.node}`],
 			description: 'Environments to support. `target` in tsconfig.json is automatically added. Defaults to the current Node.js version.',
 			alias: 't',
+		},
+		tsconfig: {
+			type: String,
+			description: 'Use a given tsconfig file',
+			alias: 'c',
+			default: 'tsconfig.json',
 		},
 		watch: {
 			type: Boolean,
@@ -109,8 +115,9 @@ const cwd = process.cwd();
  */
 const sourcePath = normalizePath(argv.flags.src, true);
 const distPath = normalizePath(argv.flags.dist, true);
+const tsconfig = parseTsconfig(argv.flags.tsconfig);
 
-const tsconfigTarget = tsconfig?.config.compilerOptions?.target;
+const tsconfigTarget = tsconfig?.compilerOptions?.target;
 if (tsconfigTarget) {
 	argv.flags.target.push(tsconfigTarget);
 }
@@ -153,6 +160,7 @@ if (tsconfigTarget) {
 		argv.flags,
 		getAliases(packageJson, cwd),
 		packageJson,
+		tsconfig
 	);
 
 	if (argv.flags.cleanDist) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,8 +44,8 @@ const argv = cli({
 		},
 		tsconfig: {
 			type: String,
-			description: 'Use a given tsconfig file',
-			alias: 'c',
+			description: 'Custom tsconfig.json file path',
+			alias: 'p',
 		},
 		watch: {
 			type: Boolean,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,7 +116,7 @@ const sourcePath = normalizePath(argv.flags.src, true);
 const distPath = normalizePath(argv.flags.dist, true);
 
 const tsconfig = getTsconfig(cwd, argv.flags.tsconfig);
-const tsconfigTarget = tsconfig.config.compilerOptions?.target;
+const tsconfigTarget = tsconfig?.config.compilerOptions?.target;
 if (tsconfigTarget) {
 	argv.flags.target.push(tsconfigTarget);
 }

--- a/src/utils/get-rollup-configs.ts
+++ b/src/utils/get-rollup-configs.ts
@@ -78,11 +78,11 @@ const getConfig = {
 		aliases: AliasMap,
 		env: EnvObject,
 		executablePaths: string[],
-		tsconfig: TsConfigResult,
+		tsconfig: TsConfigResult | null,
 	) => {
 		const esbuildConfig: TransformOptions = {
 			target: options.target,
-			tsconfigRaw: tsconfig.config,
+			tsconfigRaw: tsconfig?.config,
 		};
 
 		return {
@@ -148,7 +148,7 @@ export const getRollupConfigs = async (
 	flags: Options,
 	aliases: AliasMap,
 	packageJson: PackageJson,
-	tsconfig: TsConfigResult,
+	tsconfig: TsConfigResult | null,
 ) => {
 	const executablePaths = inputs
 		.filter(({ exportEntry }) => exportEntry.isExecutable)

--- a/src/utils/get-rollup-configs.ts
+++ b/src/utils/get-rollup-configs.ts
@@ -1,12 +1,14 @@
 import fs from 'fs';
 import path from 'path';
 import type { OutputOptions, RollupOptions, Plugin } from 'rollup';
+import type { TransformOptions } from 'esbuild';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import alias from '@rollup/plugin-alias';
 import replace from '@rollup/plugin-replace';
 import type { PackageJson } from 'type-fest';
+import type { TsConfigJsonResolved } from 'get-tsconfig';
 import type { ExportEntry, AliasMap } from '../types.js';
 import { isFormatEsm, createRequire } from './rollup-plugins/create-require.js';
 import { esbuildTransform, esbuildMinify } from './rollup-plugins/esbuild.js';
@@ -76,9 +78,11 @@ const getConfig = {
 		aliases: AliasMap,
 		env: EnvObject,
 		executablePaths: string[],
+		tsconfigRaw: TsConfigJsonResolved,
 	) => {
 		const esbuildConfig = {
 			target: options.target,
+			tsconfigRaw: tsconfigRaw as TransformOptions['tsconfigRaw'],
 		};
 
 		return {
@@ -144,6 +148,7 @@ export const getRollupConfigs = async (
 	flags: Options,
 	aliases: AliasMap,
 	packageJson: PackageJson,
+	tsconfigRaw: TsConfigJsonResolved,
 ) => {
 	const executablePaths = inputs
 		.filter(({ exportEntry }) => exportEntry.isExecutable)
@@ -204,6 +209,7 @@ export const getRollupConfigs = async (
 				aliases,
 				env,
 				executablePaths,
+				tsconfigRaw
 			);
 			config.external = externalDependencies;
 			configs.app = config;

--- a/src/utils/get-rollup-configs.ts
+++ b/src/utils/get-rollup-configs.ts
@@ -8,7 +8,7 @@ import json from '@rollup/plugin-json';
 import alias from '@rollup/plugin-alias';
 import replace from '@rollup/plugin-replace';
 import type { PackageJson } from 'type-fest';
-import type { TsConfigJsonResolved } from 'get-tsconfig';
+import type { TsConfigResult } from 'get-tsconfig';
 import type { ExportEntry, AliasMap } from '../types.js';
 import { isFormatEsm, createRequire } from './rollup-plugins/create-require.js';
 import { esbuildTransform, esbuildMinify } from './rollup-plugins/esbuild.js';
@@ -78,11 +78,11 @@ const getConfig = {
 		aliases: AliasMap,
 		env: EnvObject,
 		executablePaths: string[],
-		tsconfigRaw: TsConfigJsonResolved,
+		tsconfig: TsConfigResult,
 	) => {
-		const esbuildConfig = {
+		const esbuildConfig: TransformOptions = {
 			target: options.target,
-			tsconfigRaw: tsconfigRaw as TransformOptions['tsconfigRaw'],
+			tsconfigRaw: tsconfig.config,
 		};
 
 		return {
@@ -148,7 +148,7 @@ export const getRollupConfigs = async (
 	flags: Options,
 	aliases: AliasMap,
 	packageJson: PackageJson,
-	tsconfigRaw: TsConfigJsonResolved,
+	tsconfig: TsConfigResult,
 ) => {
 	const executablePaths = inputs
 		.filter(({ exportEntry }) => exportEntry.isExecutable)
@@ -209,7 +209,7 @@ export const getRollupConfigs = async (
 				aliases,
 				env,
 				executablePaths,
-				tsconfigRaw
+				tsconfig,
 			);
 			config.external = externalDependencies;
 			configs.app = config;

--- a/src/utils/get-tsconfig.ts
+++ b/src/utils/get-tsconfig.ts
@@ -1,10 +1,17 @@
-import { getTsconfig as _getTsconfig } from 'get-tsconfig';
+import path from 'path';
+import { getTsconfig as _getTsconfig, parseTsconfig } from 'get-tsconfig';
 
 export const getTsconfig = (
-	cwd: string,
 	tscFile?: string,
-) => (
-	tscFile
-		? _getTsconfig(cwd, tscFile)
-		: _getTsconfig()
-);
+) => {
+	if (!tscFile) {
+		return _getTsconfig();
+	}
+
+	const resolvedTscFile = path.resolve(tscFile);
+	const config = parseTsconfig(resolvedTscFile);
+	return {
+		path: resolvedTscFile,
+		config,
+	};
+};

--- a/src/utils/get-tsconfig.ts
+++ b/src/utils/get-tsconfig.ts
@@ -1,9 +1,15 @@
 import { getTsconfig as _getTsconfig } from 'get-tsconfig';
 
-export const getTsconfig = (cwd: string, tscFile?: string) => {
-	return (
+export const getTsconfig = (
+	cwd: string,
+	tscFile?: string,
+) => (
+	(
 		tscFile
 			? _getTsconfig(cwd, tscFile)
 			: _getTsconfig()
-	) ?? { path: cwd, config: {}}
-}
+	) ?? {
+		path: cwd,
+		config: {},
+	}
+);

--- a/src/utils/get-tsconfig.ts
+++ b/src/utils/get-tsconfig.ts
@@ -1,0 +1,9 @@
+import { getTsconfig as _getTsconfig } from 'get-tsconfig';
+
+export const getTsconfig = (cwd: string, tscFile?: string) => {
+	return (
+		tscFile
+			? _getTsconfig(cwd, tscFile)
+			: _getTsconfig()
+	) ?? { path: cwd, config: {}}
+}

--- a/src/utils/get-tsconfig.ts
+++ b/src/utils/get-tsconfig.ts
@@ -4,12 +4,7 @@ export const getTsconfig = (
 	cwd: string,
 	tscFile?: string,
 ) => (
-	(
-		tscFile
-			? _getTsconfig(cwd, tscFile)
-			: _getTsconfig()
-	) ?? {
-		path: cwd,
-		config: {},
-	}
+	tscFile
+		? _getTsconfig(cwd, tscFile)
+		: _getTsconfig()
 );

--- a/src/utils/rollup-plugins/esbuild.ts
+++ b/src/utils/rollup-plugins/esbuild.ts
@@ -1,7 +1,6 @@
 import type { Plugin, InternalModuleFormat } from 'rollup';
 import { createFilter } from '@rollup/pluginutils';
 import { transform, type TransformOptions, type Format } from 'esbuild';
-import { tsconfig } from '../tsconfig.js';
 
 export const esbuildTransform = (
 	options?: TransformOptions,
@@ -24,8 +23,6 @@ export const esbuildTransform = (
 
 				// https://github.com/evanw/esbuild/issues/1932#issuecomment-1013380565
 				sourcefile: id.replace(/\.[cm]ts/, '.ts'),
-
-				tsconfigRaw: tsconfig?.config as TransformOptions['tsconfigRaw'],
 			});
 
 			return {

--- a/src/utils/tsconfig.ts
+++ b/src/utils/tsconfig.ts
@@ -1,3 +1,0 @@
-import { getTsconfig } from 'get-tsconfig';
-
-export const tsconfig = getTsconfig();

--- a/tests/specs/builds/typescript.ts
+++ b/tests/specs/builds/typescript.ts
@@ -77,7 +77,7 @@ export default testSuite(({ describe }, nodePath: string) => {
 
 			const pkgrollProcess = await pkgroll([
 				'--env.NODE_ENV=test',
-				'--tsconfig=tsconfig.build.json'
+				'--tsconfig=tsconfig.build.json',
 			], {
 				cwd: fixture.path,
 				nodePath,
@@ -112,7 +112,7 @@ export default testSuite(({ describe }, nodePath: string) => {
 
 			const pkgrollProcess = await pkgroll([
 				'--env.NODE_ENV=test',
-				'--tsconfig=tsconfig.invalid.json'
+				'--tsconfig=tsconfig.invalid.json',
 			], {
 				cwd: fixture.path,
 				nodePath,
@@ -124,6 +124,5 @@ export default testSuite(({ describe }, nodePath: string) => {
 			const content = await fixture.readFile('dist/index.js', 'utf8');
 			expect(content.includes('function')).toBe(false);
 		});
-
-	})
+	});
 });

--- a/tests/specs/builds/typescript.ts
+++ b/tests/specs/builds/typescript.ts
@@ -54,8 +54,8 @@ export default testSuite(({ describe }, nodePath: string) => {
 		});
 	});
 
-	describe('cli option \'tsconfig\'', ({ test }) => {
-		test('respects defined compiler options', async () => {
+	describe('custom tsconfig.json path', ({ test }) => {
+		test('respects compile target', async () => {
 			await using fixture = await createFixture({
 				src: {
 					'index.ts': 'export default () => "foo";',
@@ -90,8 +90,8 @@ export default testSuite(({ describe }, nodePath: string) => {
 			expect(content.includes('function')).toBe(true);
 		});
 
-		test('parses default "tsconfig.json" as a fallback', async () => {
-			await using fixture = await createFixture({
+		test('error on invalid tsconfig.json path', async () => {
+			const fixture = await createFixture({
 				src: {
 					'index.ts': 'export default () => "foo";',
 				},
@@ -116,13 +116,11 @@ export default testSuite(({ describe }, nodePath: string) => {
 			], {
 				cwd: fixture.path,
 				nodePath,
+				reject: false,
 			});
 
-			expect(pkgrollProcess.exitCode).toBe(0);
-			expect(pkgrollProcess.stderr).toBe('');
-
-			const content = await fixture.readFile('dist/index.js', 'utf8');
-			expect(content.includes('function')).toBe(false);
+			expect(pkgrollProcess.exitCode).toBe(1);
+			// expect(pkgrollProcess.stderr).toMatch('Cannot resolve tsconfig at path:');
 		});
 	});
 });


### PR DESCRIPTION
Implements the cli option `--tsconfig` and solves #36

* (again) 'lint' script and some tests fail due to an 'EPERM' error (see #74)

Cheers

fixes #36
closes https://github.com/privatenumber/pkgroll/pull/37