### PR TITLE
feat: add support for nested types in subpath exports

### DIFF
--- a/src/utils/parse-package-json/get-export-entries.ts
+++ b/src/utils/parse-package-json/get-export-entries.ts
@@ -5,12 +5,15 @@ import { propertyNeedsQuotes } from '../property-needs-quotes.js';
 
 const getFileType = (
 	filePath: string,
-): PackageType | undefined => {
+): PackageType | 'types' | undefined => {
 	if (filePath.endsWith('.mjs')) {
 		return 'module';
 	}
 	if (filePath.endsWith('.cjs')) {
 		return 'commonjs';
+	}
+	if (filePath.includes('.d.')) {
+		return 'types';
 	}
 };
 

--- a/src/utils/parse-package-json/get-export-entries.ts
+++ b/src/utils/parse-package-json/get-export-entries.ts
@@ -12,7 +12,11 @@ const getFileType = (
 	if (filePath.endsWith('.cjs')) {
 		return 'commonjs';
 	}
-	if (filePath.includes('.d.')) {
+	if (
+		filePath.endsWith('.d.ts')
+		|| filePath.endsWith('.d.cts')
+		|| filePath.endsWith('.d.mts')
+	) {
 		return 'types';
 	}
 };

--- a/tests/specs/builds/package-exports.ts
+++ b/tests/specs/builds/package-exports.ts
@@ -124,7 +124,7 @@ export default testSuite(({ describe }, nodePath: string) => {
 					},
 				}),
 			});
-			
+
 			const pkgrollProcess = await pkgroll([], {
 				cwd: fixture.path,
 				nodePath,

--- a/tests/specs/builds/package-exports.ts
+++ b/tests/specs/builds/package-exports.ts
@@ -109,6 +109,37 @@ export default testSuite(({ describe }, nodePath: string) => {
 			expect(utilsCjs).toMatch('exports.sayHello =');
 		});
 
+		test('conditions - types', async () => {
+			await using fixture = await createFixture({
+				...packageFixture({
+					installTypeScript: true,
+				}),
+				'package.json': createPackageJson({
+					type: 'module',
+					exports: {
+						types: {
+							default: './dist/mts.d.ts',
+						},
+						import: './dist/mts.js',
+					},
+				}),
+			});
+			
+			const pkgrollProcess = await pkgroll([], {
+				cwd: fixture.path,
+				nodePath,
+			});
+
+			expect(pkgrollProcess.exitCode).toBe(0);
+			expect(pkgrollProcess.stderr).toBe('');
+
+			const indexMjs = await fixture.readFile('dist/mts.js', 'utf8');
+			expect(indexMjs).toMatch('function sayGoodbye(name) {');
+
+			const indexDts = await fixture.readFile('dist/mts.d.ts', 'utf8');
+			expect(indexDts).toMatch('declare function sayGoodbye(name: string): void;');
+		});
+
 		test('conditions - import should allow cjs', async () => {
 			await using fixture = await createFixture({
 				...packageFixture(),


### PR DESCRIPTION
**Problem**
In our monorepo, we have package.json's which look like this:
```
  "exports": {
    "types": {
      "development": "./src/index.ts",
      "default": "./dist/index.d.ts"
    },
    "import": "./dist/index.js"
  },
```
This is to help point VSCode at the source code for clickthrough support instead of the distributed types. However, this does not seem to work with `pkgroll`. Instead, it's producing the raw JS code into the .d.ts file.

**Solution**
It seems like this is a bug in the exports map processing. It's not capable currently of handling nested types. The only scenario where `type: 'types'` can be set, is when it's exactly the key and a string value.

While the test illustrates this point, I also added a naiive way of detecting this. In the default case (which is what we use), it does filename detection, so I reused that.

A more advanced implementation might be to look back at the current `from` path and more generically determine that it's within a "key" block like "types" to carry that forward.

But this fixed it and didn't break anything, and I think is a somewhat standard convention, so hope it helps!