### PR TITLE
Fix support hashbang on Windows

### DIFF
--- a/src/rollup/get-rollup-configs.ts
+++ b/src/rollup/get-rollup-configs.ts
@@ -120,7 +120,7 @@ export const getRollupConfigs = async (
 				entryFileNames: (chunk) => {
 					const realPath = fs.realpathSync.native(stripQuery(chunk.facadeModuleId!));
 					const relativePath = realPath.slice(sourceDirectoryPath.length);
-					const filePath = path.join(path.dirname(relativePath), chunk.name);
+					const filePath = path.posix.join(path.dirname(relativePath), chunk.name);
 					return filePath + distExtension;
 				},
 			};

--- a/src/rollup/plugins/patch-binary.ts
+++ b/src/rollup/plugins/patch-binary.ts
@@ -16,7 +16,7 @@ export const patchBinary = (
 		}
 
 		const entryFileNames = outputOptions.entryFileNames as (chunk: RenderedChunk) => string;
-		const outputPath = `./${path.posix.join(outputOptions.dir!, entryFileNames(chunk))}`;
+		const outputPath = `./${path.posix.join(outputOptions.dir!, entryFileNames(chunk).replaceAll('\\', '/'))}`;
 
 		if (executablePaths.includes(outputPath)) {
 			const transformed = new MagicString(code);

--- a/src/rollup/plugins/patch-binary.ts
+++ b/src/rollup/plugins/patch-binary.ts
@@ -16,7 +16,7 @@ export const patchBinary = (
 		}
 
 		const entryFileNames = outputOptions.entryFileNames as (chunk: RenderedChunk) => string;
-		const outputPath = `./${path.posix.join(outputOptions.dir!, entryFileNames(chunk).replaceAll('\\', '/'))}`;
+		const outputPath = `./${path.posix.join(outputOptions.dir!, entryFileNames(chunk))}`;
 
 		if (executablePaths.includes(outputPath)) {
 			const transformed = new MagicString(code);

--- a/tests/specs/builds/bin.ts
+++ b/tests/specs/builds/bin.ts
@@ -8,10 +8,10 @@ export default testSuite(({ describe }, nodePath: string) => {
 	describe('bin', ({ test }) => {
 		test('supports single path', async () => {
 			await using fixture = await createFixture({
-				...packageFixture(),
+				// Using a subpath tests that the paths are joined correctly on Windows
+				'src/subpath/bin.ts': 'console.log("Hello, world!");',
 				'package.json': createPackageJson({
-					bin: './dist/index.mjs',
-					exports: './dist/index.mjs',
+					bin: './dist/subpath/bin.mjs',
 				}),
 			});
 
@@ -24,12 +24,12 @@ export default testSuite(({ describe }, nodePath: string) => {
 			expect(pkgrollProcess.stderr).toBe('');
 
 			await test('is executable', async () => {
-				const content = await fixture.readFile('dist/index.mjs', 'utf8');
+				const content = await fixture.readFile('dist/subpath/bin.mjs', 'utf8');
 				expect(content).toMatch('#!/usr/bin/env node');
 
 				// File modes don't exist on Windows
 				if (process.platform !== 'win32') {
-					const stats = await fs.stat(`${fixture.path}/dist/index.mjs`);
+					const stats = await fs.stat(fixture.getPath('dist/subpath/bin.mjs'));
 					const unixFilePermissions = `0${(stats.mode & 0o777).toString(8)}`; // eslint-disable-line no-bitwise
 
 					expect(unixFilePermissions).toBe('0755');


### PR DESCRIPTION
Fixes the issue that a hashbang is missing from the produced cli file when building on Windows and using a source file in a subdirectory. 

fixes https://github.com/privatenumber/pkgroll/issues/110