### PR TITLE
fix: improve error messages when files are missing or mismatched

### DIFF
--- a/tests/specs/error-cases.ts
+++ b/tests/specs/error-cases.ts
@@ -106,5 +106,50 @@ export default testSuite(({ describe }, nodePath: string) => {
 			expect(pkgrollProcess.stderr).toMatch('Ignoring entry outside of ./dist/ directory: package.json#main="/dist/main.js"');
 			expect(pkgrollProcess.stderr).toMatch('No export entries found in package.json');
 		});
+
+		test('cannot find matching source file', async () => {
+			await using fixture = await createFixture({
+				...packageFixture(),
+				'package.json': createPackageJson({
+					name: 'pkg',
+					main: 'dist/missing.js',
+					module: 'dist/missing.mjs',
+				}),
+			});
+
+			const pkgrollProcess = await pkgroll(
+				[],
+				{
+					cwd: fixture.path,
+					nodePath,
+					reject: false,
+				},
+			);
+			expect(pkgrollProcess.exitCode).toBe(1);
+			expect(pkgrollProcess.stderr).toMatch('Could not find matching source file for export path');
+			expect(pkgrollProcess.stderr).toMatch('Expected: ./src/missing[.js|.ts|.tsx|.mts|.cts]');
+		});
+
+		test('unexpected extension', async () => {
+			await using fixture = await createFixture({
+				...packageFixture(),
+				'package.json': createPackageJson({
+					name: 'pkg',
+					main: 'dist/index.foo',
+				}),
+			});
+
+			const pkgrollProcess = await pkgroll(
+				[],
+				{
+					cwd: fixture.path,
+					nodePath,
+					reject: false,
+				},
+			);
+			expect(pkgrollProcess.exitCode).toBe(1);
+			expect(pkgrollProcess.stderr).toMatch('Error: Package.json output path contains invalid extension');
+			expect(pkgrollProcess.stderr).toMatch('Expected: .d.ts, .d.mts, .d.cts, .js, .mjs, .cjs');
+		});
 	});
 });


### PR DESCRIPTION
Fixes #121

**Problem**
Errors are most helpful when they give the user information about how to self-resolve them, without needing to search too deep. When the dist files cannot be matched to src files, the error right now alerts the user to that, but doesn't tell them what it expects. This requires them to go look elsewhere to realize the extension mappings or that the bare names must match.

**Solution**
We can be a little more verbose with our error messages:
- Break apart invalid dist extensions and missing source extensions into separate cases for clarity
- Include expected file name options in the error messages for each

This should create errors which give the users immediate solutions if they are using pkgroll for the first time.

NOTE: I also rewrote a `for + if` statement into a `some` statement because I find that easier to reason about. Feel free to undo that if you have strong opinions.

NOTE: I also had to jump through hoops to get the linter happy because it wouldn't let me multi-line an arrow, but also complained it was over 100 chars, but also wouldn't let me use ext as a name. So I ended up grabbing the actual prop we care about.