### PR TITLE
Unwrap default exports in CJS under default property

### DIFF
--- a/src/rollup/get-rollup-configs.ts
+++ b/src/rollup/get-rollup-configs.ts
@@ -85,6 +85,7 @@ export const getRollupConfigs = async (
 					chunkFileNames: `${srcdist.distPrefix!}[name]-[hash]${distExtension}`,
 					exports: 'auto',
 					format: 'esm',
+					interop: "auto",
 					[entrySymbol]: entry,
 				};
 


### PR DESCRIPTION
Closes #101

Injecting helpers that contain code that detects at runtime if the required value contains the [__esModule property](https://rollupjs.org/configuration-options/#output-esmodule).